### PR TITLE
fix: delete sementic-release/git on releaserc

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -1,31 +1,28 @@
- module.exports = {
+module.exports = {
   branches: [
     {
-      "name": "main"
+      name: 'main',
     },
   ],
   plugins: [
-    ["@semantic-release/commit-analyzer", {
-      "preset": "angular",
-      "releaseRules": [
-        {"type": "feat", "release": "minor"},
-        {"type": "fix", "release": "patch"},
-        {"type": "chore", "release": "patch"},
-        {"type": "refactor", "release": "patch"},
-        {"type": "style", "release": "patch"}
-      ],
-      "parserOpts": {
-        "noteKeywords": ["BREAKING CHANGE", "BREAKING CHANGES"]
-      }
-    }],
-    "@semantic-release/release-notes-generator",
-    "@semantic-release/npm",
     [
-      "@semantic-release/git",
+      '@semantic-release/commit-analyzer',
       {
-        "assets": ["package.json"]
-      }
+        preset: 'angular',
+        releaseRules: [
+          { type: 'feat', release: 'minor' },
+          { type: 'fix', release: 'patch' },
+          { type: 'chore', release: 'patch' },
+          { type: 'refactor', release: 'patch' },
+          { type: 'style', release: 'patch' },
+        ],
+        parserOpts: {
+          noteKeywords: ['BREAKING CHANGE', 'BREAKING CHANGES'],
+        },
+      },
     ],
-    "@semantic-release/github"
-  ]
-}
+    '@semantic-release/release-notes-generator',
+    '@semantic-release/npm',
+    '@semantic-release/github',
+  ],
+};


### PR DESCRIPTION
## Description
github action에서 `sementic-release/git` 모듈을 찾지 못해 `main` 브랜치 빌드에 실패 하고 있음.

## Solved
현재 사용하고 있지 않은 모듈이라 제거 했을때 이슈 없음
- `sementic-release/git` 제거
