### PR TITLE
feat: useAsyncEffect 훅 추가

### DIFF
--- a/src/hooks/useAsyncEffect.ts
+++ b/src/hooks/useAsyncEffect.ts
@@ -1,0 +1,12 @@
+import { DependencyList, useEffect } from 'react';
+
+/**
+ * useEffect로 async function을 넘기면 타입이 깨지기 때문에 사용하는 헬퍼입니다.
+ *
+ * 동작은 useEffect와 똑같지만, 이펙트가 반환하는 타입이 Promise<void>이기 때문에 클린업은 불가능합니다.
+ */
+export default function useAsyncEffect(asyncEffect: () => Promise<void>, deps: DependencyList) {
+  useEffect(() => {
+    asyncEffect();
+  }, deps);
+}


### PR DESCRIPTION
## useAsyncEffect

`useEffect`의 타입은 `() => Promise<void>` 타입을 받을 수 없도록 되어있어서 매번 내부에서 `async` 익명 함수를 한번 선언해야하는데, 그게 너무 귀찮아서 만든 타입 헬퍼 훅입니다.

```tsx
function Foo () {
  const [loading, startLoading, endLoading] = useBooleanState(true);

  useAsyncEffect(async () => {
    await delay(3000);
    endLoading();
  }, [endLoading]);

  return <div>{loading ? 'loading....' : 'Hello World!'}</div>;
}
```