### PR TITLE
Feature/add useBindInput

### DIFF
--- a/src/hooks/useBindInput.ts
+++ b/src/hooks/useBindInput.ts
@@ -1,0 +1,45 @@
+import { useState, Dispatch } from 'react';
+
+export interface BindInput {
+  value: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+export interface UseBindInput {
+  bind: BindInput;
+  setValue: Dispatch<React.SetStateAction<string>>;
+}
+
+const useBindInput = (initialValue?: string, inputValidator?: (text: string) => boolean) => {
+  const [value, setValue] = useState(initialValue ?? '');
+
+  const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const {
+      target: { value: text },
+    } = e;
+
+    if (inputValidator) {
+      const willUpdate = inputValidator(text);
+      if (willUpdate) {
+        setValue(text);
+      }
+    } else {
+      setValue(text);
+    }
+  };
+
+  const clearValue = () => {
+    setValue('');
+  };
+
+  return {
+    bind: {
+      value,
+      onChange,
+    },
+    setValue,
+    clearValue,
+  };
+};
+
+export default useBindInput;

--- a/src/hooks/useBindInput.tsx
+++ b/src/hooks/useBindInput.tsx
@@ -1,13 +1,8 @@
-import { useState, Dispatch } from 'react';
+import { useState } from 'react';
 
 export interface BindInput {
   value: string;
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
-}
-
-export interface UseBindInput {
-  bind: BindInput;
-  setValue: Dispatch<React.SetStateAction<string>>;
 }
 
 const useBindInput = (initialValue?: string, inputValidator?: (text: string) => boolean) => {

--- a/src/hooks/useBindInput.tsx
+++ b/src/hooks/useBindInput.tsx
@@ -5,7 +5,7 @@ export interface BindInput {
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
-const useBindInput = (initialValue?: string, inputValidator?: (text: string) => boolean) => {
+const useBindInput = ({ initialValue, validator }: { initialValue?: string; validator?: (text: string) => boolean }) => {
   const [value, setValue] = useState(initialValue ?? '');
 
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/hooks/useBindInput.tsx
+++ b/src/hooks/useBindInput.tsx
@@ -5,7 +5,13 @@ export interface BindInput {
   onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
-const useBindInput = (initialValue?: string, inputValidator?: (text: string) => boolean) => {
+const useBindInput = ({
+  initialValue,
+  validator,
+}: {
+  initialValue?: string;
+  validator?: (text: string) => boolean;
+}) => {
   const [value, setValue] = useState(initialValue ?? '');
 
   const onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -13,8 +19,8 @@ const useBindInput = (initialValue?: string, inputValidator?: (text: string) => 
       target: { value: text },
     } = e;
 
-    if (inputValidator) {
-      const willUpdate = inputValidator(text);
+    if (validator) {
+      const willUpdate = validator(text);
       if (willUpdate) {
         setValue(text);
       }


### PR DESCRIPTION
## useBindInput
`input`컴포넌트를 `state`로 관리 할 때 `onChange`, `value` 만들어서 매번 바인딩 해줘야하는데 간단하게 퉁탕퉁탕 `validator`까지 추가 할 수 있는 훅입니다.

```tsx
const Foo = () => {
  const reg = /[0-9]/g;
  const isNumberFormat = (text: string): boolean => reg.test(text);

  // only numbers can input
  const { bind } = useBindInput('', isNumberFormat);
  return <input {...bind} />;
};
```